### PR TITLE
Tentatively working on Dart 2.0

### DIFF
--- a/lib/src/parser/regex.dart
+++ b/lib/src/parser/regex.dart
@@ -27,9 +27,9 @@ class RegexIrcParser extends IrcParser {
         parsed.group
       );
 
-      if (!line.startsWith(":") && !line.startsWith("@")) {
-        match = [match[0], null, null, match[1], null, match[3].substring(1)];
-      }
+      //if (!line.startsWith(":") && !line.startsWith("@")) {
+      //  match = [match[0], null, null, match[1], null, match[3].substring(1)];
+      //}
     }
     var tagStuff = match[1];
     var hostmask = match[2];
@@ -40,7 +40,7 @@ class RegexIrcParser extends IrcParser {
     var tags = <String, String>{};
 
     if (tagStuff != null && tagStuff.trim().isNotEmpty) {
-      tags = IrcParserSupport.parseTags(tagStuff);
+      tags = IrcParserSupport.parseTags(tagStuff).cast<String, String>();
     }
 
     return new Message(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,8 @@ authors:
 description: A beautiful all-purpose IRC library.
 homepage: https://github.com/SpinlockLabs/irc.dart/
 environment:
-  sdk: ">=1.20.0"
+  sdk: ">=2.0.0"
 dependencies:
-  quiver: "^0.26.2"
+  quiver: ">=2.0.0"
 dev_dependencies:
-  test: "^0.12.28"
+  test: ">=1.3.0"


### PR DESCRIPTION
I would like to work with irc.dart on dart 2.0

This branch has tests compiling properly, but only by commenting out a section of the IRC Regex parser that was causing the PING test to fail.

I do NOT know the purpose of these lines, and I have not read the IRC RFC to see under which conditions this branch would be required, so please let me know!